### PR TITLE
[#6] remove unused reference to clojure.lang.RT

### DIFF
--- a/src/bencode/core.clj
+++ b/src/bencode/core.clj
@@ -10,8 +10,7 @@
   "A netstring and bencode implementation for Clojure."
   {:author "Meikel Brandmeyer"}
   (:require [clojure.java.io :as io])
-  (:import clojure.lang.RT
-           [java.io ByteArrayOutputStream
+  (:import [java.io ByteArrayOutputStream
             EOFException
             InputStream
             IOException


### PR DESCRIPTION
This solved #6. It is a left-over from #4 which I forgot to clean up.